### PR TITLE
Dfc and other quick fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ secret_token.txt
 secret_token
 discord.log
 entries_dump.txt
+secret.py
 
 # Entries
 misc/entries.db

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import logging
 
 from discord import Game, ActivityType
 from discord.ext import commands
+from secret import BOLAS_SECRET_TOKEN
 
 logging.basicConfig(level=logging.INFO)
 token = os.environ['BOLAS_SECRET_TOKEN']

--- a/src/cogs/commands.py
+++ b/src/cogs/commands.py
@@ -15,7 +15,7 @@ class Misc(commands.Cog):
 
         obey_dict = {
             # neosloth
-            120767447681728512: "I obey.",
+            120767447681728512: "Hi dad.",
             # Average Dragon
             182268688559374336: "Eat a dick, dragon.",
             # Garta
@@ -27,7 +27,9 @@ class Misc(commands.Cog):
             # Braden
             279686121149956096: "Braden is definitely lame.",
             # Sickrobot
-            98525939910078464: "*sniffle* yea, sure"
+            98525939910078464: "*sniffle* yea, sure",
+            # Melffy Bunilla
+            141131991218126848: "Hi mum."
         }
 
         if ctx.message.author.id in obey_dict.keys():
@@ -37,7 +39,7 @@ class Misc(commands.Cog):
     async def addme(self, ctx):
         """The link to add Bolas to your Discord server."""
         await ctx.send("https://discordapp.com/oauth2/authorize?"
-                       "client_id=245372541915365377&scope=bot&permissions=0")
+                       "client_id=850633920012877874&scope=bot&permissions=0")
 
     @commands.command()
     async def git(self, ctx):

--- a/src/cogs/fetcher.py
+++ b/src/cogs/fetcher.py
@@ -3,7 +3,7 @@ import re
 
 from discord import Embed
 from discord.ext import commands
-from urllib.parse import quote
+from urllib.parse import quote, quote_plus
 
 from ..scryfall import ScryFall
 
@@ -21,12 +21,12 @@ class Fetcher(commands.Cog):
         self.MAX_CARDS = 8
         self.MAX_CARDS_BEFORE_LIST = 4
         # Need to be all lowercase
-        self.CARD_NICKNAMES = {"sad robot" : "Solemn Simulacrum",
-                              "bob": "Dark Confidant",
+        self.CARD_NICKNAMES = {"sad robot" : "Solemn Simulacrum set:mrd",
+                              "bob": "Dark Confidant set:rav",
                               "steve": "Sakura-Tribe Elder",
                               "scooze": "Scavenging Ooze",
                               "gary": "Gray Merchant of Asphodel",
-                              "tim": "Prodigal Sorcerer",
+                              "tim": "Prodigal Sorcerer set:lea",
                               "prime time": "Primeval Titan",
                               "skittles": "Skithiryx, the Blight Dragon",
                               "gaaiv": "Grand Arbiter Augustin IV"
@@ -72,12 +72,12 @@ class Fetcher(commands.Cog):
                                                 max_cards=self.MAX_CARDS)
                     # In hindsight giving this an exception is dumb
                 except ScryFall.CardLimitException as e:
-                    url = "https://scryfall.com/search?q={}".format(quote(match))
+                    url = "https://scryfall.com/search?q={}".format(quote_plus(match))
                     await channel.send(f"Too many matches. You can see the full list of matched cards here: {url}")
                     continue
                 # Any generic exception provided by scryfall
                 except ScryFall.ScryfallException as e:
-                     await channel.send(e.message)
+                     await channel.send(e.message,delete_after=5)
                      continue
 
             card_count = len(cards)
@@ -104,7 +104,7 @@ class Fetcher(commands.Cog):
             cards = self.sc.search_card(cardname, max_cards=1)
             # Any generic exception provided by scryfall
         except ScryFall.ScryfallException as e:
-            await ctx.send(e.message)
+            await ctx.send(e.message,delete_after=5)
             return
         except ScryFall.CardLimitException:
             await ctx.send("Only one card per command please.")
@@ -146,12 +146,13 @@ class Fetcher(commands.Cog):
         # Send a card attribute or the associated exception message
         try:
             card = self.sc.search_card(arg, order="usd", max_cards=1)[0]
+
             # Any generic exception provided by scryfall
         except ScryFall.ScryfallException as e:
-            await ctx.send(e.message)
+            await ctx.send(e.message, delete_after=5)
             return
         except ScryFall.CardLimitException as e:
-            await ctx.send(e.message)
+            await ctx.send(e.message, delete_after=5)
             return
 
         await ctx.send(card.get_price_string())

--- a/src/scryfall.py
+++ b/src/scryfall.py
@@ -75,7 +75,8 @@ class ScryFall:
         """
         url = "{}/cards/search?order={}&q={}".format(self.API_URL,
                                                      order,
-                                                     parse.quote(query))
+                                                     parse.quote_plus(query))
+
         result = self.get_cards_from_url(url, max_cards)
         # Strip custom scryfall arguments from the cardname
         name = re.sub("[a-z]+:[a-z]+", "", query).strip().lower()
@@ -114,7 +115,7 @@ class ScryFall:
                         continue
 
                     if "card_faces" in obj:
-                        cards += [Card(face)
+                        cards += [Card(face, prices=obj["prices"])
                                   for face in obj["card_faces"]]
                     else:
                         cards.append(Card(obj))


### PR DESCRIPTION
> The price command now also works for DFC cards
>> When getting the card faces as card object, I just added the price attribute of the outer card object to the new card face card object(s)
> You can use regex like on Scryfall now
> You can search for DFC cards also with the full name using the two slashes like some websites do
>> quote_plus instead of quote, that way / is not a safe character, hence it gets passed to scryfall
> The messages that pop up when you search something embarrassingly wrong destroy themselves in 5..., 4..., 3..., 2..., 1...
>> Added a delete_after=5 to a bunch of send parts where errors happen more often, will add the rest later
> "sad robot", "bob" and "tim" now show the proper versions they reference
>> There's a dictionary of commonly used terms, there it basically exchanges those for the proper names, and there I just added the appropriate set shortcut
> When the Bolas bot owner types in !obey, it says "Hi dad." and when I type it says "Hi mum."
>> To honor theneosloth for making the original Bolas bot, and of course I'll add my own